### PR TITLE
add labels for options and head methods

### DIFF
--- a/components/api-method/api-method.component.ts
+++ b/components/api-method/api-method.component.ts
@@ -10,7 +10,8 @@ import { Operation, Response } from '../../schema/2.0/swagger.schema';
         [class.panel-info]="method == 'get'"
         [class.panel-success]="method == 'post'"
         [class.panel-warning]="method == 'put' || method == 'patch'"
-        [class.panel-danger]="method == 'delete'">
+        [class.panel-danger]="method == 'delete'"
+        [class.panel-default]="method == 'head' || method == 'options'">
       <div class="panel-heading" (click)="expanded = !expanded">
         <h3 class="panel-title">
           <http-method-label [method]="method"></http-method-label> {{urlTemplate}}

--- a/components/http-method-label/http-method-label.component.ts
+++ b/components/http-method-label/http-method-label.component.ts
@@ -9,7 +9,8 @@ import { RequestMethod } from '@angular/http';
          [class.label-info]="isGet()"
          [class.label-success]="isPost()"
          [class.label-warning]="isPutOrPatch()"
-         [class.label-danger]="isDelete()">{{getMethodName()}}</span>
+         [class.label-danger]="isDelete()"
+         [class.panel-default]="isHeadOrOptions()">{{getMethodName()}}</span>
   `,
   styles: [
       '.label { padding-top: 0.4em; }',
@@ -56,6 +57,13 @@ export class HttpMethodLabelComponent {
 
   isDelete(): boolean {
     return this.method != null && (this.method == RequestMethod.Delete || this.caseInsensitiveEquals(this.method, 'delete'));
+  }
+
+  isHeadOrOptions(): boolean {
+    return this.method != null && (this.method == RequestMethod.Head
+                        || this.method == RequestMethod.Options
+                        || this.caseInsensitiveEquals(<string>this.method, 'head')
+                        || this.caseInsensitiveEquals(<string>this.method, 'options'));
   }
 
   private caseInsensitiveEquals(v1: string|RequestMethod, v2: string): boolean {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swangular-components",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Swagger UI components written in angular 2",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When using swangular for another project, we noticed there were no label colorings for head or options like there are for the other methods so they default to white, which is impossible to read if the background of the page is also white. Since its trivial, decided I'd make the changes instead of asking you to. Hopefully they help. 